### PR TITLE
Add new command Relative

### DIFF
--- a/contrail_api_cli/commands/relative.py
+++ b/contrail_api_cli/commands/relative.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from ..resource import Resource
+from ..command import Command, Arg, CommandError, expand_paths
+from ..utils import format_table
+from six import text_type
+
+RESOURCE_NAME_PATH_SEPARATOR = "."
+
+
+class Relative(Command):
+    description = "Get linked resources by providing a resource name path"
+    path = Arg(help="Base resource", metavar='path')
+    resource_name_path = Arg(help="Resource names separated by '%s'" % RESOURCE_NAME_PATH_SEPARATOR,
+                             metavar='resource_name_path')
+    show_intermediate = Arg('-l', '--show-intermediate',
+                            default=False, action="store_true",
+                            help="show intermediate resources")
+
+    def _get_next_resource(self, resource, next_resource_name):
+        """
+        :param resource: Resource (not necessary fetched)
+        :param next_resource_name: string
+        :rtype: (resource_type, resource_path)
+        """
+        resource.fetch()
+
+        # Try to generate the attribute corresponding to the resource type
+        type_suffix = {"ref": "_refs", "back_ref": "_back_refs", "child": ""}
+        for k, v in type_suffix.items():
+            if next_resource_name + v in resource:
+                next_resource_attr = next_resource_name + v
+                next_resource_type = k
+                break
+        else:
+            raise CommandError("Resource '%s' is not linked to resource type '%s'" % (resource.path, next_resource_name))
+
+        next_resource = resource.get(next_resource_attr)
+        if len(next_resource) > 0:
+            return (next_resource_type, next_resource[0])
+        else:
+            return (None, None)
+
+    def __call__(self, path=None, resource_name_path=None,
+                 show_intermediate=False):
+
+        def long_format(resource_type, resource_path):
+            return "%8s %s" % (resource_type, resource_path)
+
+        # Get the base resource
+        resources = expand_paths([path],
+                                 predicate=lambda r: isinstance(r, Resource))
+        resource = resources[0]
+        resource_type = "base"
+
+        resource_name_paths = resource_name_path.split(
+            RESOURCE_NAME_PATH_SEPARATOR)
+
+        # Build resources along the path
+        result = [(resource_type, resource)]
+        for resource_name in resource_name_paths:
+            resource_type, resource = self._get_next_resource(
+                resource, resource_name)
+            result.append((resource_type, resource))
+
+        result = [(t, self.current_path(r)) for t, r in result]
+        if show_intermediate:
+            return format_table(result)
+        else:
+            return text_type(result[-1][1])

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
             'tree = contrail_api_cli.commands.tree:Tree',
             'python = contrail_api_cli.command:Python',
             'schema = contrail_api_cli.commands.schema:Schema',
+            'relative = contrail_api_cli.commands.relative:Relative',
         ],
         'contrail_api_cli.shell_command': [
             'cd = contrail_api_cli.command:Cd',


### PR DESCRIPTION
This command permits to get the uuid of a linked resource, by
providing a resource and a resource type path. The resource type path
is a list of resource types separated by dots.

For instance, to get the logical router associated to a virtual
machine interface that implements a SNAT:
contrail-api-cli relative virtual-machine-interface/737cad4e-b4ca-4e67-a3f0-fb1996a63a05 virtual_machine.service_instance.logical_router