### PR TITLE
Use gevent ssl module

### DIFF
--- a/contrail_api_cli/utils.py
+++ b/contrail_api_cli/utils.py
@@ -19,6 +19,7 @@ from .exceptions import AbsPathRequired
 
 
 gevent.monkey.patch_socket()
+gevent.monkey.patch_ssl()
 logger = logging.getLogger(__name__)
 CONFIG_DIR = os.path.expanduser('~/.config/contrail-api-cli')
 


### PR DESCRIPTION
Monkeypatck the ssl module to use gevent.

Without this change attempts to communicate with an SSL URL resulted in,

`do_handshake_on_connect should not be specified for non-blocking sockets`