### PR TITLE
Fix TypeError when using edit without args

### DIFF
--- a/contrail_api_cli/commands/edit.py
+++ b/contrail_api_cli/commands/edit.py
@@ -23,7 +23,7 @@ class Edit(Command):
     on an existing resource.
     """
     description = "Edit resource"
-    path = Arg(nargs="?", help="Resource path",
+    path = Arg(help="Resource path",
                complete='resources::path')
     template = Option('-t',
                       help="Create new resource from existing",


### PR DESCRIPTION
Fixes: https://github.com/eonpatapon/contrail-api-cli/issues/21

Granted, I'm not sure if this is intended "edit" behaviour.