### PR TITLE
Support to use different HTTP sessions

### DIFF
--- a/contrail_api_cli/client.py
+++ b/contrail_api_cli/client.py
@@ -45,7 +45,8 @@ class SessionLoader(loading.session.Session):
         """
         loader = loading.base.get_plugin_loader(os_auth_type)
         plugin_options = {opt.dest: kwargs.pop("os_%s" % opt.dest)
-                          for opt in loader.get_options()}
+                          for opt in loader.get_options()
+                          if 'os_%s' % opt.dest in kwargs}
         plugin = loader.load_from_options(**plugin_options)
         return self.load_from_argparse_arguments(Namespace(**kwargs),
                                                  host=host,
@@ -99,7 +100,10 @@ class ContrailAPISession(Session):
 
     @property
     def user(self):
-        return self.auth.username
+        if hasattr(self.auth, 'username'):
+            return self.auth.username
+        else:
+            return 'unknown'
 
     @property
     def base_url(self):

--- a/contrail_api_cli/resource.py
+++ b/contrail_api_cli/resource.py
@@ -158,6 +158,9 @@ class ResourceEncoder(json.JSONEncoder):
 
 class ResourceBase(Observable):
 
+    def __init__(self, session=None):
+        self._session = session
+
     def __repr__(self):
         return '%s(%s)' % (self.__class__.__name__, self.path)
 
@@ -170,6 +173,8 @@ class ResourceBase(Observable):
 
     @property
     def session(self):
+        if self._session is not None:
+            return self._session
         return Context().session
 
     @property
@@ -234,7 +239,8 @@ class Collection(ResourceBase, UserList):
     def __init__(self, type, fetch=False, recursive=1,
                  fields=None, detail=None, filters=None,
                  parent_uuid=None, back_refs_uuid=None,
-                 data=None):
+                 data=None, session=None):
+        super(Collection, self).__init__(session=session)
         UserList.__init__(self, initlist=data)
         self.type = type
         self.fields = fields or []
@@ -422,8 +428,9 @@ class Resource(ResourceBase, UserDict):
     """
 
     def __init__(self, type, fetch=False, check=False,
-                 parent=None, recursive=1, **kwargs):
+                 parent=None, recursive=1, session=None, **kwargs):
         assert('fq_name' in kwargs or 'uuid' in kwargs or 'to' in kwargs)
+        super(Resource, self).__init__(session=session)
         self.type = type
 
         UserDict.__init__(self, kwargs)

--- a/contrail_api_cli/tests/test_resource.py
+++ b/contrail_api_cli/tests/test_resource.py
@@ -391,6 +391,11 @@ class TestResource(CLITest):
         mock_session.post_json.assert_called_with(self.BASE + '/ref-update', data)
         self.assertTrue('bar_refs' not in r1)
 
+    def test_resource_with_defined_session_2(self):
+        mock_session = mock.MagicMock(base_url=self.BASE)
+        Resource('foo', uuid="fake_uuid", session=mock_session, fetch=True)
+        mock_session.get_json.assert_called_with(self.BASE + '/foo/fake_uuid')
+
 
 class TestCollection(CLITest):
 
@@ -517,6 +522,11 @@ class TestCollection(CLITest):
         mock_session.get_json.side_effect = HttpError(http_status=404)
         with self.assertRaises(CollectionNotFound):
             Collection('foo', fetch=True)
+
+    def test_collection_with_defined_session(self):
+        mock_session = mock.MagicMock(base_url=self.BASE)
+        Collection('foo', session=mock_session, fetch=True)
+        mock_session.get_json.assert_called_with(self.BASE + '/foos')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add support to specifying different HTTP session when we requesting
Collection or Resources instead to use the global one contained in the
Context. That permits to instantiate and maintain sessions with
different credentials.