### PR TITLE
Catch case Contrail forbids to modify system resources

### DIFF
--- a/contrail_api_cli/exceptions.py
+++ b/contrail_api_cli/exceptions.py
@@ -81,3 +81,12 @@ class BackRefsExists(Exists):
 
     def __str__(self):
         return "Back references from %s exists" % self._paths
+
+
+class SystemResource(GreenletExit):
+
+    def __init__(self, resource=None):
+        self._resource = resource
+
+    def __str__(self):
+        return "System resource %s cannot be changed" % self._resource

--- a/contrail_api_cli/exceptions.py
+++ b/contrail_api_cli/exceptions.py
@@ -83,10 +83,7 @@ class BackRefsExists(Exists):
         return "Back references from %s exists" % self._paths
 
 
-class SystemResource(GreenletExit):
-
-    def __init__(self, resource=None):
-        self._resource = resource
+class IsSystemResource(Exists):
 
     def __str__(self):
-        return "System resource %s cannot be changed" % self._resource
+        return "System resources %s cannot be changed" % self._paths

--- a/contrail_api_cli/resource.py
+++ b/contrail_api_cli/resource.py
@@ -20,7 +20,7 @@ from prompt_toolkit.completion import Completion
 
 from .utils import FQName, Path, Observable, to_json
 from .exceptions import ResourceNotFound, ResourceMissing, \
-    CollectionNotFound, ChildrenExists, BackRefsExists
+    CollectionNotFound, ChildrenExists, BackRefsExists, SystemResource
 from .context import Context
 
 
@@ -73,6 +73,10 @@ def http_error_handler(f):
                 if matches:
                     raise BackRefsExists(
                         resources=list(hrefs_to_resources(matches.group(1))))
+            elif e.http_status == 400:
+                matches = re.match(r'^Routing instance .*\(([a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12})\) cannot modify as it the default routing instance of the .*\)$', e.message)
+                if matches:
+                    raise SystemResource(resource=Resource(type='routing-instance', uuid=matches.group(1)))
             raise
     return wrapper
 

--- a/contrail_api_cli/resource.py
+++ b/contrail_api_cli/resource.py
@@ -20,7 +20,7 @@ from prompt_toolkit.completion import Completion
 
 from .utils import FQName, Path, Observable, to_json
 from .exceptions import ResourceNotFound, ResourceMissing, \
-    CollectionNotFound, ChildrenExists, BackRefsExists, SystemResource
+    CollectionNotFound, ChildrenExists, BackRefsExists, IsSystemResource
 from .context import Context
 
 
@@ -56,27 +56,27 @@ def http_error_handler(f):
                     raise CollectionNotFound(collection=self)
             elif e.http_status == 409:
                 # contrail 3.2
-                matches = re.match(r'^Delete when children still present: (\[[^]]*\])', e.message)
+                matches = re.match(r'^Delete when children still present: (\[[^]]*\])($| \(HTTP 409\)$)', e.message)
                 if matches:
                     raise ChildrenExists(
                         resources=list(hrefs_list_to_resources(matches.group(1))))
-                matches = re.match(r'^Delete when resource still referred: (\[[^]]*\])', e.message)
+                matches = re.match(r'^Delete when resource still referred: (\[[^]]*\])($| \(HTTP 409\)$)', e.message)
                 if matches:
                     raise BackRefsExists(
                         resources=list(hrefs_list_to_resources(matches.group(1))))
                 # contrail 2.21
-                matches = re.match(r'^Children (.*) still exist$', e.message)
+                matches = re.match(r'^Children (.*) still exist($| \(HTTP 409\)$)', e.message)
                 if matches:
                     raise ChildrenExists(
                         resources=list(hrefs_to_resources(matches.group(1))))
-                matches = re.match(r'^Back-References from (.*) still exist$', e.message)
+                matches = re.match(r'^Back-References from (.*) still exist($| \(HTTP 409\)$)', e.message)
                 if matches:
                     raise BackRefsExists(
                         resources=list(hrefs_to_resources(matches.group(1))))
-            elif e.http_status == 400:
-                matches = re.match(r'^Routing instance .*\(([a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12})\) cannot modify as it the default routing instance of the .*\)$', e.message)
+                # contrail 5.1
+                matches = re.match(r'^Cannot modify system resource (.*) .*\(([a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12})\)($| \(HTTP 409\)$)', e.message)
                 if matches:
-                    raise SystemResource(resource=Resource(type='routing-instance', uuid=matches.group(1)))
+                    raise IsSystemResource(resources=[Resource(matches.group(1), uuid=matches.group(2))])
             raise
     return wrapper
 


### PR DESCRIPTION
System resource cannot be modified by the user like the default routing
instance of virtual network. Contrail takes care of them.