### PR TITLE
schema: parent becomes a list

### DIFF
--- a/contrail_api_cli/commands/schema.py
+++ b/contrail_api_cli/commands/schema.py
@@ -73,7 +73,13 @@ class Schema(Command):
             'node': resource_name,
             'childs': []
         }
-        for type in ('parent', 'children', 'refs', 'back_refs', 'properties'):
+        parents = getattr(resource, "parents")
+        if parents:
+            tree['childs'].append({
+                'node': "parent",
+                'childs': [{'node': " | ".join(parents)}]
+            })
+        for type in ('children', 'refs', 'back_refs', 'properties'):
             childs = getattr(resource, type)
             if not childs:
                 continue

--- a/contrail_api_cli/schema.py
+++ b/contrail_api_cli/schema.py
@@ -130,7 +130,7 @@ def fill_schema_from_xsd_file(filename, schema):
             target = schema._get_or_add_resource(target_name)
             if "has" in v[3]:
                 src.children.append(target_name)
-                target.parent = src_name
+                target.parents.append(src_name)
             if "ref" in v[3]:
                 src.refs.append(target_name)
                 target.back_refs.append(src_name)
@@ -194,14 +194,14 @@ class ResourceSchema(object):
 
     def __init__(self):
         self.children = []
-        self.parent = None
+        self.parents = []
         self.refs = []
         self.back_refs = []
         self.properties = []
 
     def json(self):
         data = {'children': self.children,
-                'parent': self.parent,
+                'parents': self.parents,
                 'refs': self.refs,
                 'back_refs': self.back_refs,
                 'properties': self.properties}


### PR DESCRIPTION
Because a resource can have different types of parents. For instance, a
`floating-ip` can have an `instance-ip` or a `floating-ip-pool` as
parent.

Note we don't render them as several children in the tree because a
resource can only have one parent. We separate potential parents  with
a `|`:

    contrail-api-cli schema --schema-version 5.0 floating-ip
    floating-ip
    ├── parent
    │   └── floating-ip-pool | instance-ip
    ├── refs
    ...